### PR TITLE
Added cell style "wrap-option" support

### DIFF
--- a/ods/Style.cpp
+++ b/ods/Style.cpp
@@ -184,6 +184,22 @@ Style::SetBackgroundColor(const QColor &color)
 }
 
 void
+Style::SetWrapOption(bool wrap)
+{
+	if (!style_family_->IsCell())
+	{
+		mtl_warn("Not implemented yet");
+		return;
+	}
+
+	auto &ns = tag_->ns();
+	auto *tag = GetTag(ods::style::tag::SheetCellProps);
+	tag->AttrSet(ns.fo(), ods::style::kWrapOption,
+        wrap ? "wrap" : "no-wrap");
+}
+
+
+void
 Style::SetBold(const bool yes)
 {
 	if (yes)
@@ -418,7 +434,6 @@ Style::SetUniqueName()
 		if (book_->GetStyle(name_, style_family_->id()) == nullptr)
 			break;
 	}
-	
 	tag_->AttrSet(tag_->ns().style(), ods::ns::kName, name_);
 }
 

--- a/ods/Style.hpp
+++ b/ods/Style.hpp
@@ -123,7 +123,8 @@ public:
 	
 	ods::Tag*
 	tag() const { return tag_; }
-	
+
+    void SetWrapOption(bool wrap);
 private:
 	NO_ASSIGN_COPY_MOVE(Style);
 	

--- a/ods/style/style.hxx
+++ b/ods/style/style.hxx
@@ -135,6 +135,7 @@ ods_const kTruncateOnOverflow	= "truncate-on-overflow";
 ods_const kUseOptimalRowHeight	= "use-optimal-row-height";
 ods_const kVerticalAlign		= "vertical-align";
 ods_const kWidth				= "width";
+ods_const kWrapOption			= "wrap-option";
 ods_const kWritingMode			= "writing-mode";
 ods_const kWritingModeLrtb		= "lr-tb";
 ods_const kZIndex				= "z-index";

--- a/ods/style/tag.cc
+++ b/ods/style/tag.cc
@@ -127,6 +127,7 @@ HeaderFooterProps(ods::Ns &ns, ods::Tag *tag)
 	tag->Add(ns.fo(), ods::style::kMarginTop);
 	tag->Add(ns.fo(), ods::style::kMinHeight);
 	tag->Add(ns.fo(), ods::style::kPadding);
+	tag->Add(ns.fo(), ods::style::kWrapOption);
 	
 	//tag->SubfuncAdd(ods::tag::tag::BackgroundImage);
 	return nullptr;
@@ -420,6 +421,7 @@ SheetCellProps(ods::Ns &ns, ods::Tag *tag)
 	tag->Add(ns.fo(), ods::style::kBorderRight);
 	tag->Add(ns.fo(), ods::style::kBorderTop);
 	tag->Add(ns.fo(), ods::style::kBackgroundColor);
+	tag->Add(ns.fo(), ods::style::kWrapOption);
 	tag->Add(ns.style(), ods::style::kRepeatContent);
 	tag->Add(ns.style(), ods::style::kRotationAngle);
 	tag->Add(ns.style(), ods::style::kTextAlignSource);


### PR DESCRIPTION
This does work but it does not modify the row height.

The next step would be to improve Row::SetOptimalHeightStyle() to make it compute how many extra text lines will be created by the wrapping.