### PR TITLE
Allow to compile with a namespaced Qt installation

### DIFF
--- a/ods/Attr.hpp
+++ b/ods/Attr.hpp
@@ -11,8 +11,8 @@
 #include "Prefix.hpp"
 #include "err.hpp"
 
-class QXmlStreamAttributes;
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamAttributes)
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ods	{ // ods::
 class Attrs;

--- a/ods/Attrs.hpp
+++ b/ods/Attrs.hpp
@@ -11,8 +11,8 @@
 #include "err.hpp"
 #include <QXmlStreamAttributes>
 
-class QXmlStreamReader;
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamReader)
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ods	{ // ods::
 class Attr;

--- a/ods/Book.hpp
+++ b/ods/Book.hpp
@@ -20,7 +20,7 @@
 #include <QTemporaryDir>
 #include <QVector>
 
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ods	{
 

--- a/ods/Content.hpp
+++ b/ods/Content.hpp
@@ -17,7 +17,7 @@
 #include <QVector>
 #include <QXmlStreamReader>
 
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ods	{
 

--- a/ods/Row.hpp
+++ b/ods/Row.hpp
@@ -12,7 +12,7 @@
 #include "global.hxx"
 #include <QVector>
 
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ods	{
 class Cell;

--- a/ods/Sheet.hpp
+++ b/ods/Sheet.hpp
@@ -13,8 +13,8 @@
 #include <QString>
 #include <QVector>
 
-class QXmlStreamReader;
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamReader)
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ods	{
 

--- a/ods/ods.hh
+++ b/ods/ods.hh
@@ -17,7 +17,7 @@
 #include "global.hxx"
 #include "Duration.hpp"
 
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ods	{ // ods::
 

--- a/ods/style/Manager.hpp
+++ b/ods/style/Manager.hpp
@@ -13,7 +13,7 @@
 #include <QString>
 #include <QXmlStreamReader>
 
-class QXmlStreamWriter;
+QT_FORWARD_DECLARE_CLASS(QXmlStreamWriter)
 
 namespace ods	{ // ods::
 


### PR DESCRIPTION
This change also allows to compile QOds with a Qt installation which was configured with a namespace (configure -qtnamespace xxx)