### PR TITLE
Fix loss of precision when saving doubles.

### DIFF
--- a/ods/Cell.cpp
+++ b/ods/Cell.cpp
@@ -28,6 +28,7 @@
 #include "Tag.hpp"
 #include "util.hh"
 #include "Value.hpp"
+#include <float.h>
 
 #include <QFont>
 #include <QFontMetricsF>
@@ -292,7 +293,7 @@ Cell::SetCurrencyValue(const double num, ods::Style *style)
 		style->GetCurrencyStyle()->info()->currency().iso);
 
 	// now set the string value + the currency symbol to show up
-	const QString value = QString::number(num);
+	const QString value = QString::number(num, 'f', FLT_DIG);
 	tag_->AttrSet(ns.office(), ods::ns::kValue, value);
 	tag_->SetTextP(value + QStringLiteral(" €"));
 	if (tag_->attrs() != nullptr)
@@ -501,7 +502,7 @@ Cell::SetValue(const double num)
 	auto &ns = tag_->ns();
 	tag_->AttrDelete(ns.office(), ods::ns::kDateValue);
 	tag_->AttrSet(ns.office(), ods::ns::kValueType, ods::ns::kDouble);
-	const QString value = QString::number(num);
+	const QString value = QString::number(num, 'f', FLT_DIG);
 	tag_->AttrSet(ns.office(), ods::ns::kValue, value);
 	tag_->SetTextP(value);
 	if (tag_->attrs() != nullptr)

--- a/ods/Value.cpp
+++ b/ods/Value.cpp
@@ -10,6 +10,7 @@
 #include "ns.hxx"
 #include "Tag.hpp"
 #include <QStringRef>
+#include <float.h>
 
 namespace ods	{
 
@@ -211,7 +212,7 @@ Value::toString() const
 		return QLatin1String("");
 	
 	if (IsDouble() || IsPercentage() || IsCurrency())
-		return QString::number(*AsDouble());
+		return QString::number(*AsDouble(), 'f', FLT_DIG);
 	if (IsString())
 		return *AsString();
 	if (IsDate())


### PR DESCRIPTION
A cell with a value of 3890172 € would end up as
3890170 € in LibreOffice, due to the default precision of
QString::number (6 digits).

I used the same fix ('f', FLT_DIG) in calligra many years ago, for the same issue.