### PR TITLE
Fix calls to mtl_line()

### DIFF
--- a/app/test/util.hh
+++ b/app/test/util.hh
@@ -13,7 +13,7 @@ test_files_dir_path()
 	QDir dir(QCoreApplication::applicationDirPath());
 	
 	if (!dir.cdUp() || !dir.cdUp())
-		mtl_line();
+		mtl_line("");
 	
 	return dir.absolutePath() + "/app/test/data_files/";
 }

--- a/ods/Cell.cpp
+++ b/ods/Cell.cpp
@@ -56,13 +56,13 @@ Cell::ComputeHeightInPixels(const int col_width_in_pixels)
 {
 	if (style_ == nullptr)
 	{
-		mtl_line();
+		mtl_line("");
 		return -1;
 	}
 	
 	if (style_->font_size_type() == ods::FontSizeType::NotSet)
 	{
-		mtl_line();
+		mtl_line("");
 		return -1;
 	}
 	
@@ -70,7 +70,7 @@ Cell::ComputeHeightInPixels(const int col_width_in_pixels)
 	
 	if (wrap_option == nullptr || *wrap_option != "wrap")
 	{
-		mtl_line();
+		mtl_line("");
 		return -1;
 	}
 	
@@ -78,7 +78,7 @@ Cell::ComputeHeightInPixels(const int col_width_in_pixels)
 	
 	if (s == nullptr)
 	{
-		mtl_line();
+		mtl_line("");
 		return -1;
 	}
 	

--- a/ods/Row.cpp
+++ b/ods/Row.cpp
@@ -271,7 +271,7 @@ Row::AdjustHeightBy(ods::Cell *cell)
 	
 	if (max_size == -1)
 	{
-		mtl_line();
+		mtl_line("");
 		if (set_style)
 		{
 			delete opt_row_height_style_;


### PR DESCRIPTION
The first argument of the macro must be provided, or it will
cause warnings on MSVC (C4003) or Clang
(-Wgnu-zero-variadic-macro-arguments). GCC accepts it as an extension,
but it's technically illegal ([cpp.replace/5]).